### PR TITLE
🚀 [Feature] #11 - 로그인 시 RefreshToken 발급 기능 추가

### DIFF
--- a/src/main/java/com/gbsw/gbswhub/domain/global/SecurityConfig.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/global/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                new AntPathRequestMatcher("/api/login"),
+                                new AntPathRequestMatcher("/api/login/**"),
                                 new AntPathRequestMatcher("/api/signup")
                         )
                         .permitAll()

--- a/src/main/java/com/gbsw/gbswhub/domain/jwt/db/AccessTokenResponse.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/jwt/db/AccessTokenResponse.java
@@ -8,14 +8,13 @@ import lombok.Setter;
 @Getter
 @Setter
 @AllArgsConstructor
-@NoArgsConstructor
 public class AccessTokenResponse {
     private String message;
     private String token;
     private String refreshToken;
 
-    public AccessTokenResponse(String message) {
-        this.message = message;
+    public AccessTokenResponse(String string) {
+        this.message = string;
         this.token = null;
         this.refreshToken = null;
     }

--- a/src/main/java/com/gbsw/gbswhub/domain/jwt/db/CreateAccessTokenByRefreshToken.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/jwt/db/CreateAccessTokenByRefreshToken.java
@@ -1,0 +1,11 @@
+package com.gbsw.gbswhub.domain.jwt.db;
+
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CreateAccessTokenByRefreshToken {
+    private String refreshToken;
+}

--- a/src/main/java/com/gbsw/gbswhub/domain/jwt/db/RefreshTokenRepository.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/jwt/db/RefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package com.gbsw.gbswhub.domain.jwt.db;
+
+import com.gbsw.gbswhub.domain.jwt.model.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByUsername(String username);
+}

--- a/src/main/java/com/gbsw/gbswhub/domain/jwt/model/RefreshToken.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/jwt/model/RefreshToken.java
@@ -1,0 +1,28 @@
+package com.gbsw.gbswhub.domain.jwt.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(updatable = false)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String refreshToken;
+
+    public RefreshToken(String username, String refreshToken){
+        this.username = username;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/gbsw/gbswhub/domain/jwt/provider/TokenProvider.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/jwt/provider/TokenProvider.java
@@ -32,7 +32,7 @@ public class TokenProvider {
         parser = Jwts.parser().verifyWith(key).build();
     }
 
-    public String generateToken(User user, Duration expiredAt) {
+    public String generateToken(User user, Duration expiredAt, boolean isAccessToken) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + expiredAt.toMillis());
 
@@ -43,6 +43,7 @@ public class TokenProvider {
                 .issuedAt(now)
                 .expiration(expiry)
                 .subject(user.getUsername())
+                .add("type", isAccessToken? "A":"R")
                 .add("id", user.getId())
                 .and()
                 .signWith(key, Jwts.SIG.HS256)
@@ -51,6 +52,9 @@ public class TokenProvider {
 
     public Authentication getAuthentication(String token) {
         Claims claims = getClaims(token);
+
+        String type = claims.get("type").toString();
+        if(type == null || !claims.get("type").equals("A")) throw new IllegalArgumentException("");
 
         List<GrantedAuthority> authorities = new ArrayList<>();
         authorities.add(new SimpleGrantedAuthority("user"));

--- a/src/main/java/com/gbsw/gbswhub/domain/jwt/service/TokenService.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/jwt/service/TokenService.java
@@ -2,10 +2,16 @@ package com.gbsw.gbswhub.domain.jwt.service;
 
 import com.gbsw.gbswhub.domain.global.Exception.BadRequestException;
 import com.gbsw.gbswhub.domain.jwt.db.AccessTokenRequest;
+import com.gbsw.gbswhub.domain.jwt.db.AccessTokenResponse;
+import com.gbsw.gbswhub.domain.jwt.db.CreateAccessTokenByRefreshToken;
+import com.gbsw.gbswhub.domain.jwt.db.RefreshTokenRepository;
+import com.gbsw.gbswhub.domain.jwt.model.RefreshToken;
 import com.gbsw.gbswhub.domain.jwt.properties.JwtProperties;
 import com.gbsw.gbswhub.domain.jwt.provider.TokenProvider;
 import com.gbsw.gbswhub.domain.user.model.User;
 import com.gbsw.gbswhub.domain.user.service.UserService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -16,17 +22,56 @@ import java.time.Duration;
 @Service
 public class TokenService {
     private final TokenProvider tokenProvider;
+    private final UserService userService;
     private final PasswordEncoder passwordEncoder;
     private final JwtProperties jwtProperties;
-    private final UserService userService;
+    private final RefreshTokenRepository refreshTokenRepository;
 
-    public String getAccessToken(AccessTokenRequest request) {
+    public AccessTokenResponse getAccessToken(AccessTokenRequest request) {
         User user = userService.getUser(request.getUsername());
-
-        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-            throw new BadRequestException("비밀번호가 올바르지 않습니다.");
+        if (user != null) {
+            if (passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+                return createAccessToken(user, null);
+            }
         }
-        // 토큰 생성
-        return tokenProvider.generateToken(user, Duration.ofDays(jwtProperties.getDuration()));
+        return null;
+    }
+
+    private AccessTokenResponse createAccessToken(User user, String refreshToken) {
+        Duration tokenDuration = Duration.ofDays(jwtProperties.getDuration());
+        Duration refreshDutation = Duration.ofDays(jwtProperties.getRefreshDuration());
+
+        RefreshToken savedRefreshToken = refreshTokenRepository.findByUsername(user.getUsername()).orElse(null);
+
+        if (savedRefreshToken != null && refreshToken != null) {
+            if (!savedRefreshToken.getRefreshToken().equals(refreshToken))
+                return new AccessTokenResponse("Invalid token", null, null);
+        }
+        String accessToken = tokenProvider.generateToken(user, tokenDuration, true);
+        String newRefreshToken = tokenProvider.generateToken(user, refreshDutation, false);
+
+        if (savedRefreshToken == null)
+            savedRefreshToken = new RefreshToken(user.getUsername(), newRefreshToken);
+        else
+            savedRefreshToken.setRefreshToken(newRefreshToken);
+        refreshTokenRepository.save(savedRefreshToken);
+        return new AccessTokenResponse("ok", accessToken, newRefreshToken);
+    }
+
+    public AccessTokenResponse refreshAccessToken(CreateAccessTokenByRefreshToken request) {
+        try{
+            Claims claims = tokenProvider.getClaims(request.getRefreshToken());
+            String type = claims.get("type").toString();
+            if(type == null || !type.equals("R")) {
+                throw new Exception("Invalid token");
+            }
+            User user = userService.getUser(claims.getSubject());
+            return createAccessToken(user, request.getRefreshToken());
+        } catch (ExpiredJwtException e) {
+            return new AccessTokenResponse("만료된 토큰", null, null);
+        } catch (Exception e){
+            System.out.println(e.getMessage());
+            return new AccessTokenResponse(e.getMessage(), null, null);
+        }
     }
 }


### PR DESCRIPTION
🔹작업 내용
로그인 시 RefreshToken을 발급하는 기능을 추가했습니다
🔍 변경 사항 상세
API 수정:
POST /api/login 엔드포인트 수정 - AccessToken과 refreshToken을 같이 발급
이메일과 비밀번호를 입력하면 데이터 베이스에 저장된 사용자 이메일 비밀번호와 일치하는지 검증
일치한다면 토큰 발급 일치하지 않다면 400에러로 오류 반환
API 추가:
POST/api/login/token
AccessToken이 만료되었을 시 엔드포인트로 RefreshToken을 포함해 요청을 보내면 새로운 AccessToken과 갱신된 RefreshToken 반환 RefreshToken도 만료되었을 시 재로그인 필요
⚠️ 주의 사항 & 중점적으로 봐야 할 부분
로그인 실패 시, 적절한 에러 메시지가 반환되는지 확인 아이디와 비밀번호가 잘못되었을때 동일한 오류 반환(400 BadRequest)
토큰이 만료되거나 유효하지 않을 시 적절한 에러 메세지가 반환되는지 확인