### PR TITLE
🚀[Feature] 동아리 & 멘토멘티 참가 요청 취소 API 추가

### DIFF
--- a/src/main/java/com/gbsw/gbswhub/domain/ai/model/Ai.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/ai/model/Ai.java
@@ -13,7 +13,7 @@ import lombok.*;
 public class Ai {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long ai_id;
+    private Long id;
 
     @Column(nullable = false)
     private String question;

--- a/src/main/java/com/gbsw/gbswhub/domain/club/model/Club.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/club/model/Club.java
@@ -15,7 +15,7 @@ import java.time.LocalDate;
 public class Club {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long club_id;
+    private Long id;
 
     @Column(nullable = false)
     private String name;
@@ -41,4 +41,8 @@ public class Club {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    public boolean isLeader(User user) {
+        return this.user != null && this.user.equals(user);
+    }
 }

--- a/src/main/java/com/gbsw/gbswhub/domain/club/service/ClubService.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/club/service/ClubService.java
@@ -56,7 +56,7 @@ public class ClubService {
                 .map(club -> {
 
                     return new ClubDto(
-                            club.getClub_id(),
+                            club.getId(),
                             club.getName(),
                             club.getDescription(),
                             club.getLocation(),
@@ -74,7 +74,7 @@ public class ClubService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.CLUB_NOT_FOUND));
 
         return new ClubDto(
-                club.getClub_id(),
+                club.getId(),
                 club.getName(),
                 club.getDescription(),
                 club.getLocation(),
@@ -107,7 +107,7 @@ public class ClubService {
         clubRepository.save(club);
 
         return new ClubDto(
-                club.getClub_id(),
+                club.getId(),
                 club.getName(),
                 club.getDescription(),
                 club.getLocation(),

--- a/src/main/java/com/gbsw/gbswhub/domain/global/Error/ErrorCode.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/global/Error/ErrorCode.java
@@ -23,6 +23,8 @@ public enum ErrorCode {
 
     PART_CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "동아리 신청을 찾을 수 없습니다."),
 
+    PART_NOT_FOUND(HttpStatus.NOT_FOUND, "신청을 찾을 수 없습니다."),
+
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
 
     INVALID_REQUEST(HttpStatus.UNAUTHORIZED, "유효하지 않은 요청입니다."),
@@ -33,7 +35,9 @@ public enum ErrorCode {
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
 
-    USERNAME_DUPLICATION(HttpStatus.CONFLICT, "이미 사용 중인 아이디입니다");
+    USERNAME_DUPLICATION(HttpStatus.CONFLICT, "이미 사용 중인 아이디입니다."),
+
+    ALREADY_PARTICIPATED(HttpStatus.CONFLICT, "이미 신청한 모집글입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/gbsw/gbswhub/domain/global/SwaggerConfig.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/global/SwaggerConfig.java
@@ -43,6 +43,7 @@ public class SwaggerConfig {
                 .addResponses("RequestClub200", createErrorResponse("동아리 모집에 참가 신청 되었습니다.", 200))
                 .addResponses("Club200", createErrorResponse("동아리 모집 공고가 생성되었습니다.", 200))
                 .addResponses("Ai200", createErrorResponse("ai 응답이 생성되었습니다.", 200))
+                .addResponses("RequestDelete200", createErrorResponse("삭제 요청이 생성되었습니다", 200))
                 .addResponses("400", createErrorResponse("잘못된 입력값입니다.", 400))
                 .addResponses("401", createErrorResponse("비밀번호가 일치하지 않습니다.", 401))
                 .addResponses("403", createErrorResponse("접근 권한이 없습니다.", 403))

--- a/src/main/java/com/gbsw/gbswhub/domain/jwt/provider/TokenProvider.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/jwt/provider/TokenProvider.java
@@ -61,6 +61,7 @@ public class TokenProvider {
         authorities.add(new SimpleGrantedAuthority("user"));
         authorities.add(new SimpleGrantedAuthority("club_leader"));
         authorities.add(new SimpleGrantedAuthority("admin"));
+        authorities.add(new SimpleGrantedAuthority("mentor"));
 
         UserDetails userDetails = org.springframework.security.core.userdetails.User
                 .withUsername(claims.getSubject())

--- a/src/main/java/com/gbsw/gbswhub/domain/participation/controller/ParticipationController.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/participation/controller/ParticipationController.java
@@ -1,6 +1,13 @@
 package com.gbsw.gbswhub.domain.participation.controller;
 
 import com.gbsw.gbswhub.domain.participation.db.*;
+import com.gbsw.gbswhub.domain.participation.db.club.RequestClubDto;
+import com.gbsw.gbswhub.domain.participation.db.club.ResponseClubDto;
+import com.gbsw.gbswhub.domain.participation.db.club.UpdateClubStatusDto;
+import com.gbsw.gbswhub.domain.participation.db.mentoring.RequestMentoringDto;
+import com.gbsw.gbswhub.domain.participation.db.mentoring.ResponseMentoringDto;
+import com.gbsw.gbswhub.domain.participation.db.mentoring.UpdateMentoringStatusDto;
+import com.gbsw.gbswhub.domain.participation.db.project.RequestProjectDto;
 import com.gbsw.gbswhub.domain.participation.service.ParticipationService;
 import com.gbsw.gbswhub.domain.user.model.User;
 import com.gbsw.gbswhub.domain.user.service.UserService;
@@ -112,5 +119,52 @@ public class ParticipationController {
         User user = userService.getUser(principal.getName());
 
         return ResponseEntity.ok(participationService.getMyParticipations(user));
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "참가 요청 삭제", description = ".")
+    @ApiResponse(responseCode = "204", ref = "#/components/responses/204")
+    @ApiResponse(responseCode = "401", ref = "#/components/responses/Login401")
+    @ApiResponse(responseCode = "403", ref = "#/components/responses/403")
+    @ApiResponse(responseCode = "404", ref = "#/components/responses/404")
+    @ApiResponse(responseCode = "500", ref = "#/components/responses/500")
+    public ResponseEntity<Void> deleteParticipation(@PathVariable Long id, Principal principal) {
+        User user = userService.getUser(principal.getName());
+
+        participationService.deleteParticipation(id, user);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/club{id}")
+    @Operation(summary = "특정 동아리 신청 내역 조회", description = "동아리장이 자신의 동아리의 신청 내역을 모두 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "요청 목록 조회 성공",
+            content = @Content(mediaType = "application/json",
+                    array = @ArraySchema(schema = @Schema(implementation = ResponseClubDto.class))))
+    @ApiResponse(responseCode = "401", ref = "#/components/responses/Login401")
+    @ApiResponse(responseCode = "403", ref = "#/components/responses/403")
+    @ApiResponse(responseCode = "404", ref = "#/components/responses/404")
+    @ApiResponse(responseCode = "500", ref = "#/components/responses/500")
+    public ResponseEntity<List<ResponseClubDto>> getAllClubById(@PathVariable Long id, Principal principal){
+        User user = userService.getUser(principal.getName());
+
+        List<ResponseClubDto> dtoList = participationService.getRequestByClub(user, id);
+        return ResponseEntity.ok(dtoList);
+    }
+
+    @GetMapping("/mentoring/{id}")
+    @Operation(summary = "특정 멘토멘티 신청 내역 조회", description = "멘토가 자신의 멘토링 신청 내역을 모두 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "요청 목록 조회 성공",
+            content = @Content(mediaType = "application/json",
+                    array = @ArraySchema(schema = @Schema(implementation = ResponseClubDto.class))))
+    @ApiResponse(responseCode = "401", ref = "#/components/responses/Login401")
+    @ApiResponse(responseCode = "403", ref = "#/components/responses/403")
+    @ApiResponse(responseCode = "404", ref = "#/components/responses/404")
+    @ApiResponse(responseCode = "500", ref = "#/components/responses/500")
+    public ResponseEntity<List<ResponseMentoringDto>> getAllMentoringById(@PathVariable Long id, Principal principal) {
+        User user = userService.getUser(principal.getName());
+
+        List<ResponseMentoringDto> dtoList = participationService.getRequestByMentoring(user, id);
+
+        return ResponseEntity.ok(dtoList);
     }
 }

--- a/src/main/java/com/gbsw/gbswhub/domain/participation/db/ParticipationRepository.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/participation/db/ParticipationRepository.java
@@ -1,6 +1,8 @@
 package com.gbsw.gbswhub.domain.participation.db;
 
+import com.gbsw.gbswhub.domain.club.model.Club;
 import com.gbsw.gbswhub.domain.participation.model.Participation;
+import com.gbsw.gbswhub.domain.project.model.Project;
 import com.gbsw.gbswhub.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +10,8 @@ import java.util.List;
 
 public interface ParticipationRepository extends JpaRepository<Participation, Long> {
     List<Participation> findByUser(User user);
+    List<Participation> findAllByClub_Id(Long clubId);
+    List<Participation> findAllByProject_Id(Long projectId);
+    boolean existsByUserAndClub(User user, Club club);
+    boolean existsByUserAndProject(User user, Project project);
 }

--- a/src/main/java/com/gbsw/gbswhub/domain/participation/db/club/RequestClubDto.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/participation/db/club/RequestClubDto.java
@@ -1,0 +1,45 @@
+package com.gbsw.gbswhub.domain.participation.db.club;
+
+import com.gbsw.gbswhub.domain.participation.model.Participation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+@NoArgsConstructor
+public class RequestClubDto {
+
+    @NotBlank(message = "소개글을  입력해주세요.")
+    @Schema(example = "동아리에 가입하고싶어요.")
+    private String introduce;
+
+    @NotBlank(message = "이름을  입력해주세요.")
+    @Schema(example = "이수환")
+    private String name;
+
+    @NotBlank(message = "학년을  입력해주세요.")
+    @Schema(example = "3학년")
+    private String grade;
+
+    @NotBlank(message = "반을  입력해주세요.")
+    @Schema(example = "1반")
+    private String classNo;
+
+    @NotBlank(message = "번호를 입력해주세요.")
+    @Schema(example = "16번")
+    private String studentNo;
+
+    @NotNull(message = "동아리 ID를 입력해주세요.")
+    @Schema(example = "1")
+    private Long clubId;
+
+    @Schema(example = "CLUB")
+    private Participation.Type type = Participation.Type.CLUB;
+
+    @Schema(example = "REQUESTED")
+    private Participation.Status status = Participation.Status.REQUESTED;
+}

--- a/src/main/java/com/gbsw/gbswhub/domain/participation/db/club/ResponseClubDto.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/participation/db/club/ResponseClubDto.java
@@ -1,0 +1,49 @@
+package com.gbsw.gbswhub.domain.participation.db.club;
+
+import com.gbsw.gbswhub.domain.participation.model.Participation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+@NoArgsConstructor
+public class ResponseClubDto {
+
+    @NotNull(message = "id는 비어있을 수 없습니다.")
+    @Schema(example = "1")
+    private Long id;
+
+    @NotBlank(message = "소개글은 비어있을 수 없습니다.")
+    @Schema(example = "동아리에 가입하고싶어요.")
+    private String introduce;
+
+    @NotBlank(message = "이름은 비어있을 수 없습니다.")
+    @Schema(example = "이수환")
+    private String name;
+
+    @NotBlank(message = "학년은 비어있을 수 없습니다.")
+    @Schema(example = "3학년")
+    private String grade;
+
+    @NotBlank(message = "반은 비어있을 수 없습니다.")
+    @Schema(example = "1반")
+    private String classNo;
+
+    @NotBlank(message = "번호는 비어있을 수 없습니다.")
+    @Schema(example = "16번")
+    private String studentNo;
+
+    @NotNull(message = "동아리 ID는 비어있을 수 없습니다.")
+    @Schema(example = "1")
+    private Long clubId;
+
+    @Schema(example = "CLUB")
+    private Participation.Type type = Participation.Type.CLUB;
+
+    @Schema(example = "REQUESTED")
+    private Participation.Status status = Participation.Status.REQUESTED;
+}

--- a/src/main/java/com/gbsw/gbswhub/domain/participation/db/club/UpdateClubStatusDto.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/participation/db/club/UpdateClubStatusDto.java
@@ -1,9 +1,7 @@
-package com.gbsw.gbswhub.domain.participation.db;
+package com.gbsw.gbswhub.domain.participation.db.club;
 
 import com.gbsw.gbswhub.domain.participation.model.Participation;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,10 +10,10 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@NoArgsConstructor
 @AllArgsConstructor
-public class UpdateMentoringStatusDto {
-    @Enumerated(EnumType.STRING)
+@NoArgsConstructor
+public class UpdateClubStatusDto {
+
     @NotNull(message = "상태를 입력해주세요.")
     @Schema(example = "APPROVED")
     private Participation.Status status;

--- a/src/main/java/com/gbsw/gbswhub/domain/participation/db/mentoring/RequestMentoringDto.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/participation/db/mentoring/RequestMentoringDto.java
@@ -1,4 +1,4 @@
-package com.gbsw.gbswhub.domain.participation.db;
+package com.gbsw.gbswhub.domain.participation.db.mentoring;
 
 import com.gbsw.gbswhub.domain.participation.model.Participation;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -11,23 +11,26 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@AllArgsConstructor
 @NoArgsConstructor
-public class RequestClubDto {
+@AllArgsConstructor
+public class RequestMentoringDto {
+    @NotBlank(message = "역할을 입력해주세요.")
+    @Schema(example = "백엔드")
+    private String position;
 
-    @NotBlank(message = "소개글을  입력해주세요.")
-    @Schema(example = "동아리에 가입하고싶어요.")
+    @NotBlank(message = "소개글을 입력해주세요.")
+    @Schema(example = "열심히 할게요!")
     private String introduce;
 
-    @NotBlank(message = "이름을  입력해주세요.")
+    @NotBlank(message = "이름을 입력해주세요.")
     @Schema(example = "이수환")
     private String name;
 
-    @NotBlank(message = "학년을  입력해주세요.")
+    @NotBlank(message = "학년을 입력해주세요.")
     @Schema(example = "3학년")
     private String grade;
 
-    @NotBlank(message = "반을  입력해주세요.")
+    @NotBlank(message = "반을 입력해주세요.")
     @Schema(example = "1반")
     private String classNo;
 
@@ -35,13 +38,14 @@ public class RequestClubDto {
     @Schema(example = "16번")
     private String studentNo;
 
-    @NotNull(message = "동아리 ID를 입력해주세요.")
+    @NotNull(message = "프로젝트 ID를 입력해주세요.")
     @Schema(example = "1")
-    private Long clubId;
+    private Long ProjectId;
 
-    @Schema(example = "CLUB")
-    private Participation.Type type = Participation.Type.CLUB;
+    @Schema(example = "MENTORING")
+    private Participation.Type type = Participation.Type.MENTORING;
 
+    @NotNull(message = "상태를 입력해주세요.")
     @Schema(example = "REQUESTED")
     private Participation.Status status = Participation.Status.REQUESTED;
 }

--- a/src/main/java/com/gbsw/gbswhub/domain/participation/db/mentoring/ResponseMentoringDto.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/participation/db/mentoring/ResponseMentoringDto.java
@@ -1,51 +1,48 @@
-package com.gbsw.gbswhub.domain.participation.db;
+package com.gbsw.gbswhub.domain.participation.db.mentoring;
 
 import com.gbsw.gbswhub.domain.participation.model.Participation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
-@NoArgsConstructor
 @AllArgsConstructor
-public class RequestMentoringDto {
-    @NotBlank(message = "역할을 입력해주세요.")
+@Builder
+@NoArgsConstructor
+public class ResponseMentoringDto {
+    @NotNull(message = "id는 비어있을 수 없습니다.")
+    @Schema(example = "1")
+    private Long id;
+
+    @NotBlank(message = "역할은 비어있을 수 없습니다.")
     @Schema(example = "백엔드")
     private String position;
 
-    @NotBlank(message = "소개글을 입력해주세요.")
+    @NotBlank(message = "소개글은 비어있을 수 없습니다.")
     @Schema(example = "열심히 할게요!")
     private String introduce;
 
-    @NotBlank(message = "이름을 입력해주세요.")
+    @NotBlank(message = "이름은 비어있을 수 없습니다.")
     @Schema(example = "이수환")
     private String name;
 
-    @NotBlank(message = "학년을 입력해주세요.")
+    @NotBlank(message = "학년은 비어있을 수 없습니다")
     @Schema(example = "3학년")
     private String grade;
 
-    @NotBlank(message = "반을 입력해주세요.")
+    @NotBlank(message = "반은 비어있을 수 없습니다.")
     @Schema(example = "1반")
     private String classNo;
 
-    @NotBlank(message = "번호를 입력해주세요.")
+    @NotBlank(message = "번호는 비어있을 수 없습니다.")
     @Schema(example = "16번")
     private String studentNo;
 
-    @NotNull(message = "프로젝트를 입력해주세요.")
-    @Schema(example = "1")
-    private Long ProjectId;
-
-    @Schema(example = "MENTORING")
     private Participation.Type type = Participation.Type.MENTORING;
 
-    @NotNull(message = "상태를 입력해주세요.")
     @Schema(example = "REQUESTED")
+    @NotNull(message = "상태는 비어있을 수 없습니다.")
     private Participation.Status status = Participation.Status.REQUESTED;
 }

--- a/src/main/java/com/gbsw/gbswhub/domain/participation/db/mentoring/UpdateMentoringStatusDto.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/participation/db/mentoring/UpdateMentoringStatusDto.java
@@ -1,7 +1,9 @@
-package com.gbsw.gbswhub.domain.participation.db;
+package com.gbsw.gbswhub.domain.participation.db.mentoring;
 
 import com.gbsw.gbswhub.domain.participation.model.Participation;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,10 +12,10 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@AllArgsConstructor
 @NoArgsConstructor
-public class UpdateClubStatusDto {
-
+@AllArgsConstructor
+public class UpdateMentoringStatusDto {
+    @Enumerated(EnumType.STRING)
     @NotNull(message = "상태를 입력해주세요.")
     @Schema(example = "APPROVED")
     private Participation.Status status;

--- a/src/main/java/com/gbsw/gbswhub/domain/participation/db/project/RequestProjectDto.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/participation/db/project/RequestProjectDto.java
@@ -1,4 +1,4 @@
-package com.gbsw.gbswhub.domain.participation.db;
+package com.gbsw.gbswhub.domain.participation.db.project;
 import com.gbsw.gbswhub.domain.participation.model.Participation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -23,6 +23,6 @@ public class RequestProjectDto {
 
     private Participation.Type type = Participation.Type.PROJECT;
 
-    @Schema(example = "REQUESTED")
+    @Schema(example = "APPROVED")
     private Participation.Status status = Participation.Status.APPROVED;
 }

--- a/src/main/java/com/gbsw/gbswhub/domain/participation/model/Participation.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/participation/model/Participation.java
@@ -71,6 +71,15 @@ public class Participation {
     public enum Status {
         REQUESTED,
         APPROVED,
-        REJECTED,
+    }
+
+    public boolean canBeDeletedBy(User user) {
+        if (this.project != null) {
+            return this.project.isOwner(user);
+        }
+        if (this.club != null) {
+            return this.club.isLeader(user);
+        }
+        return false;
     }
 }

--- a/src/main/java/com/gbsw/gbswhub/domain/participation/model/Status.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/participation/model/Status.java
@@ -3,5 +3,4 @@ package com.gbsw.gbswhub.domain.participation.model;
 public enum Status {
     REQUESTED,
     APPROVED,
-    REJECTED
 }

--- a/src/main/java/com/gbsw/gbswhub/domain/project/Service/MentoringService.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/project/Service/MentoringService.java
@@ -72,7 +72,7 @@ public class MentoringService {
                             .collect(Collectors.toList());
 
                     return new MentoringDto(
-                            project.getProject_id(),
+                            project.getId(),
                             project.getTitle(),
                             project.getContent(),
                             project.getPeople(),
@@ -106,7 +106,7 @@ public class MentoringService {
                 .collect(Collectors.toList());
 
         return new MentoringDto(
-                project.getProject_id(),
+                project.getId(),
                 project.getTitle(),
                 project.getContent(),
                 project.getPeople(),
@@ -158,7 +158,7 @@ public class MentoringService {
                 .collect(Collectors.toList());
 
         return new MentoringDto(
-                project.getProject_id(),
+                project.getId(),
                 project.getTitle(),
                 project.getContent(),
                 project.getPeople(),

--- a/src/main/java/com/gbsw/gbswhub/domain/project/Service/ProjectService.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/project/Service/ProjectService.java
@@ -70,7 +70,7 @@ public class ProjectService {
                             .collect(Collectors.toList());
 
                     return new ProjectDto(
-                            project.getProject_id(),
+                            project.getId(),
                             project.getTitle(),
                             project.getContent(),
                             project.getPeople(),
@@ -97,7 +97,7 @@ public class ProjectService {
                 .collect(Collectors.toList());
 
         return new ProjectDto(
-                project.getProject_id(),
+                project.getId(),
                 project.getTitle(),
                 project.getContent(),
                 project.getPeople(),
@@ -144,7 +144,7 @@ public class ProjectService {
                 .collect(Collectors.toList());
 
         return new ProjectDto(
-                project.getProject_id(),
+                project.getId(),
                 project.getTitle(),
                 project.getContent(),
                 project.getPeople(),

--- a/src/main/java/com/gbsw/gbswhub/domain/project/db/ProjectRepository.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/project/db/ProjectRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
     @Modifying
-    @Query("UPDATE Project p SET p.view_count = p.view_count + 1 WHERE p.project_id = :id")
+    @Query("UPDATE Project p SET p.view_count = p.view_count + 1 WHERE p.id = :id")
     void incrementViewCount(@Param("id") Long id);
 
     List<Project> findByType(Project.Type type);

--- a/src/main/java/com/gbsw/gbswhub/domain/project/model/Project.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/project/model/Project.java
@@ -20,7 +20,7 @@ import java.util.List;
 public class Project {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long project_id;
+    private Long id;
 
     @Column(nullable = false)
     private String title;
@@ -71,6 +71,10 @@ public class Project {
     public enum Type {
         PROJECT,
         MENTORING
+    }
+
+    public boolean isOwner(User user) {
+        return this.user != null && this.user.getUser_id().equals(user.getUser_id());
     }
 }
 

--- a/src/main/java/com/gbsw/gbswhub/domain/project/model/Stack.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/project/model/Stack.java
@@ -13,7 +13,7 @@ public class Stack {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long stack_id;
+    private Long id;
 
     @Column(nullable = false)
     private String stack_name;

--- a/src/main/java/com/gbsw/gbswhub/domain/user/model/User.java
+++ b/src/main/java/com/gbsw/gbswhub/domain/user/model/User.java
@@ -31,6 +31,9 @@ public class User {
     @Column(nullable = false)
     private String classNumber; //반
 
+    @Column
+    private String studentNumber;
+
     @Column(nullable = false)
     private String department; //과
 
@@ -41,6 +44,6 @@ public class User {
     public enum Role {
         USER,
         ADMIN,
-        CLUB_LEADER
+        CLUB_LEADER,
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,5 +22,6 @@ jwt.refresh-duration=7
 logging.level.com.gbsw.gbswhub=DEBUG
 logging.level.org.springframework=DEBUG
 
+spring.ai.openai.api-key=k-proj-cP9Kweoz0lRHN8yNaEALT3BlbkFJQ6pMeXgXUoDxxaQaRlFF
 spring.ai.openai.base-url=https://api.openai.com/v1/chat/completions
 spring.ai.openai.chat.model=gpt-3.5-turbo


### PR DESCRIPTION
🔹작업 내용
동아리장과 멘토가 자신이 모집한 글의 모집 신청을 조회하는 API를 추가했습니다.
동아리장과 멘토가 모집글의 참가 요청을 삭제하는 API를 추가했습니다.
🔍 변경 사항 상세
- Swagger에 get /api/participation/mentoring/{id} 엔드포인트를 추가했습니다.
- Swagger에 get /api/participation/club/{id} 엔드포인트를 추가했습니다.
- Swagger에 delete /api/participation/{id} 엔드포인트를 추가했습니다.
